### PR TITLE
gate wasm bindings behind feature

### DIFF
--- a/src/ast/context/context_object_builder.rs
+++ b/src/ast/context/context_object_builder.rs
@@ -1,18 +1,17 @@
-use std::collections::HashMap;
-use std::rc::Rc;
-use std::cell::RefCell;
-use log::trace;
 use crate::ast::context::context_object::{ContextObject, ExpressionEntry, MethodEntry};
 use crate::ast::context::context_object_type::FormalParameter;
-use crate::ast::token::{DefinitionEnum, ExpressionEnum};
 use crate::ast::token::DefinitionEnum::MetaphorDefinition;
+use crate::ast::token::{DefinitionEnum, ExpressionEnum};
 use crate::link::node_data::{Node, NodeData, NodeDataEnum};
 use crate::typesystem::types::ValueType;
+use log::trace;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
 
 /// ---
 /// **ContextObjectBuilder**
 /// - Builds Execution Context Object and gets dismissed after building.
-
 pub struct ContextObjectBuilder {
     fields: HashMap<String, Rc<RefCell<ExpressionEntry>>>,
     metaphors: HashMap<String, Rc<RefCell<MethodEntry>>>,
@@ -21,6 +20,12 @@ pub struct ContextObjectBuilder {
     context_type: Option<ValueType>,
     parameters: Vec<FormalParameter>,
     node_type: NodeDataEnum<ContextObject>,
+}
+
+impl Default for ContextObjectBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ContextObjectBuilder {
@@ -65,8 +70,9 @@ impl ContextObjectBuilder {
             return self;
         }
 
-        trace!(">>> inserting field {:?}",field_name);
-        self.fields.insert(field_name.to_string(), ExpressionEntry::from(field).into());
+        trace!(">>> inserting field {:?}", field_name);
+        self.fields
+            .insert(field_name.to_string(), ExpressionEntry::from(field).into());
 
         self
     }
@@ -74,9 +80,10 @@ impl ContextObjectBuilder {
     pub fn add_definition(&mut self, field: DefinitionEnum) {
         match field {
             MetaphorDefinition(metaphor) => {
-                trace!(">>> inserting function {:?}",metaphor.get_name());
+                trace!(">>> inserting function {:?}", metaphor.get_name());
                 self.field_names.push(metaphor.get_name());
-                self.metaphors.insert(metaphor.get_name(), MethodEntry::from(metaphor).into());
+                self.metaphors
+                    .insert(metaphor.get_name(), MethodEntry::from(metaphor).into());
             }
         }
     }
@@ -117,11 +124,17 @@ impl ContextObjectBuilder {
 
     pub fn merge(target: Rc<RefCell<ContextObject>>, another: Rc<RefCell<ContextObject>>) {
         for (key, value) in another.borrow().expressions.iter() {
-            target.borrow_mut().expressions.insert(key.clone(), Rc::clone(value));
+            target
+                .borrow_mut()
+                .expressions
+                .insert(key.clone(), Rc::clone(value));
         }
 
         for (key, value) in another.borrow().metaphors.iter() {
-            target.borrow_mut().metaphors.insert(key.clone(), Rc::clone(value));
+            target
+                .borrow_mut()
+                .metaphors
+                .insert(key.clone(), Rc::clone(value));
         }
 
         for (key, value) in another.borrow().node().get_childs().borrow().iter() {
@@ -131,16 +144,25 @@ impl ContextObjectBuilder {
                 continue;
             }
 
-            target.borrow().node().add_child(key.clone(), Rc::clone(value));
+            target
+                .borrow()
+                .node()
+                .add_child(key.clone(), Rc::clone(value));
         }
 
         // Merge metaphors by name
         for (key, value) in another.borrow().metaphors.iter() {
-            target.borrow_mut().metaphors.insert(key.clone(), Rc::clone(value));
+            target
+                .borrow_mut()
+                .metaphors
+                .insert(key.clone(), Rc::clone(value));
         }
 
         // Update field_names and deduplicate them
-        target.borrow_mut().all_field_names.extend(another.borrow().get_field_names());
+        target
+            .borrow_mut()
+            .all_field_names
+            .extend(another.borrow().get_field_names());
         target.borrow_mut().all_field_names.sort_unstable();
         target.borrow_mut().all_field_names.dedup();
     }
@@ -161,9 +183,15 @@ impl ContextObjectBuilder {
 
         let ctx = Rc::new(RefCell::new(obj));
 
-        ctx.borrow().node().get_childs().borrow().iter().for_each(|(name, child)| {
-            child.borrow_mut().node.node_type = NodeDataEnum::Child(name.clone(), Rc::downgrade(&ctx));
-        });
+        ctx.borrow()
+            .node()
+            .get_childs()
+            .borrow()
+            .iter()
+            .for_each(|(name, child)| {
+                child.borrow_mut().node.node_type =
+                    NodeDataEnum::Child(name.clone(), Rc::downgrade(&ctx));
+            });
 
         ctx
     }

--- a/src/ast/context/context_object_type.rs
+++ b/src/ast/context/context_object_type.rs
@@ -1,15 +1,17 @@
-use core::fmt;
-use std::cell::RefCell;
-use std::fmt::{Debug, Display, Formatter};
-use std::rc::Rc;
 use crate::ast::context::context_object::{ContextObject, ExpressionEntry, MethodEntry};
-use crate::ast::context::context_object_type::EObjectContent::{ConstantValue, Definition, ExpressionRef, MetaphorRef, ObjectRef};
+use crate::ast::context::context_object_type::EObjectContent::{
+    ConstantValue, Definition, ExpressionRef, MetaphorRef, ObjectRef,
+};
 use crate::ast::expression::StaticLink;
 use crate::ast::Link;
 use crate::link::linker::link_parts;
 use crate::link::node_data::Node;
 use crate::typesystem::types::{TypedValue, ValueType};
 use crate::typesystem::values::ValueEnum;
+use core::fmt;
+use std::cell::RefCell;
+use std::fmt::{Debug, Display, Formatter};
+use std::rc::Rc;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FormalParameter {
@@ -57,7 +59,7 @@ impl StaticLink for EObjectContent<ContextObject> {
             }
             ObjectRef(value) => match link_parts(Rc::clone(value)) {
                 Ok(_) => Ok(ValueType::ObjectType(Rc::clone(value))),
-                Err(err) => Err(err)
+                Err(err) => Err(err),
             },
             Definition(definition) => Ok(definition.clone()),
         }
@@ -78,14 +80,14 @@ impl<T: Node<T>> Display for EObjectContent<T> {
 
 #[cfg(test)]
 pub mod test {
-    use std::rc::Rc;
-    use log::info;
     use crate::ast::context::context_object_builder::*;
     use crate::ast::metaphors::functions::FunctionDefinition;
-    use crate::ast::token::ExpressionEnum;
     use crate::ast::token::DefinitionEnum::MetaphorDefinition;
+    use crate::ast::token::ExpressionEnum;
     use crate::link::linker::link_parts;
-    use crate::runtime::edge_rules::{EvalError, expr};
+    use crate::runtime::edge_rules::{expr, EvalError};
+    use log::info;
+    use std::rc::Rc;
 
     use crate::utils::test::init_logger;
 
@@ -130,7 +132,10 @@ pub mod test {
 
         link_parts(Rc::clone(&obj3))?;
 
-        assert_eq!(obj3.borrow().to_type_string(), "Type<a: number, b: number, x: string, y: number>");
+        assert_eq!(
+            obj3.borrow().to_type_string(),
+            "Type<a: number, b: number, x: string, y: number>"
+        );
 
         Ok(())
     }
@@ -149,11 +154,15 @@ pub mod test {
             let mut child = ContextObjectBuilder::new();
             child.add_expression("x", E::from("Hello"));
             child.add_expression("y", expr("a + b")?);
-            child.add_definition(MetaphorDefinition(FunctionDefinition::build(
-                vec![],
-                "income".to_string(),
-                vec![],
-                ContextObjectBuilder::new().build()).into()));
+            child.add_definition(MetaphorDefinition(
+                FunctionDefinition::build(
+                    vec![],
+                    "income".to_string(),
+                    vec![],
+                    ContextObjectBuilder::new().build(),
+                )
+                .into(),
+            ));
             builder.add_expression("c", ExpressionEnum::StaticObject(child.build()));
         }
 
@@ -161,8 +170,14 @@ pub mod test {
 
         link_parts(Rc::clone(&obj))?;
 
-        assert_eq!(obj.borrow().to_string(), "{a : 1; b : 2; c : {x : 'Hello'; y : a + b; income() : {}}}");
-        assert_eq!(obj.borrow().to_type_string(), "Type<a: number, b: number, c: Type<x: string, y: number>>");
+        assert_eq!(
+            obj.borrow().to_string(),
+            "{a : 1; b : 2; c : {x : 'Hello'; y : a + b; income() : {}}}"
+        );
+        assert_eq!(
+            obj.borrow().to_type_string(),
+            "Type<a: number, b: number, c: Type<x: string, y: number>>"
+        );
 
         Ok(())
     }

--- a/src/ast/context/mod.rs
+++ b/src/ast/context/mod.rs
@@ -1,4 +1,4 @@
-pub mod context_object_type;
 pub mod context_object;
 pub mod context_object_builder;
+pub mod context_object_type;
 pub mod function_context;

--- a/src/ast/foreach.rs
+++ b/src/ast/foreach.rs
@@ -1,25 +1,25 @@
+use crate::ast::context::context_object::ContextObject;
+use crate::ast::context::context_object_builder::ContextObjectBuilder;
+use crate::ast::context::context_object_type::FormalParameter;
+use crate::ast::context::function_context::{FunctionContext, RETURN_EXPRESSION};
+use crate::ast::expression::{EvaluatableExpression, StaticLink};
+use crate::ast::token::ExpressionEnum;
+use crate::ast::token::ExpressionEnum::Value;
+use crate::ast::{is_linked, Link};
+use crate::link::linker::link_parts;
+use crate::link::node_data::{NodeData, NodeDataEnum};
+use crate::runtime::execution_context::*;
+use crate::tokenizer::utils::Either;
+use crate::typesystem::errors::{LinkingError, RuntimeError};
+use crate::typesystem::types::{Integer, TypedValue, ValueType};
+use crate::typesystem::values::ValueEnum;
+use crate::typesystem::values::ValueEnum::{Array, RangeValue};
+use crate::utils::context_unwrap;
 use std::cell::RefCell;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 use std::rc::Rc;
-use crate::ast::expression::{EvaluatableExpression, StaticLink};
-use crate::ast::token::ExpressionEnum::Value;
-use crate::ast::token::{ExpressionEnum};
-use crate::runtime::execution_context::*;
-use crate::typesystem::errors::{LinkingError, RuntimeError};
-use crate::typesystem::types::{Integer, TypedValue, ValueType};
-use crate::typesystem::values::ValueEnum;
-use crate::typesystem::values::ValueEnum::{Array, RangeValue};
-use crate::ast::context::context_object::ContextObject;
-use crate::ast::context::context_object_builder::ContextObjectBuilder;
-use crate::ast::context::function_context::{FunctionContext, RETURN_EXPRESSION};
-use crate::ast::{is_linked, Link};
-use crate::ast::context::context_object_type::FormalParameter;
-use crate::link::linker::link_parts;
-use crate::link::node_data::{NodeData, NodeDataEnum};
-use crate::tokenizer::utils::Either;
-use crate::utils::{context_unwrap};
 
 /// for in_loop_variable in in_expression return return_expression
 /// in_expression.map(in_loop_variable -> return_expression)
@@ -36,7 +36,11 @@ pub struct ForFunction {
 impl Display for ForFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let return_expression = context_unwrap(self.return_expression.borrow().to_string());
-        write!(f, "for {} in {} return {}", self.in_loop_variable, self.in_expression, return_expression)
+        write!(
+            f,
+            "for {} in {} return {}",
+            self.in_loop_variable, self.in_expression, return_expression
+        )
     }
 }
 
@@ -50,7 +54,11 @@ impl Display for Either<ExpressionEnum, FunctionContext> {
 }
 
 impl ForFunction {
-    pub fn new(in_loop_variable: String, in_expression: ExpressionEnum, return_expression: ExpressionEnum) -> Self {
+    pub fn new(
+        in_loop_variable: String,
+        in_expression: ExpressionEnum,
+        return_expression: ExpressionEnum,
+    ) -> Self {
         let mut builder = ContextObjectBuilder::new();
         builder.add_expression(RETURN_EXPRESSION, return_expression);
 
@@ -62,41 +70,69 @@ impl ForFunction {
         }
     }
 
-    fn create_in_loop_context(&self, parent: &Rc<RefCell<ExecutionContext>>, value: ExpressionEnum) -> Rc<RefCell<ExecutionContext>> {
+    fn create_in_loop_context(
+        &self,
+        parent: &Rc<RefCell<ExecutionContext>>,
+        value: ExpressionEnum,
+    ) -> Rc<RefCell<ExecutionContext>> {
         let mut obj = ContextObjectBuilder::new();
         obj.add_expression(self.in_loop_variable.as_str(), value);
 
         ExecutionContext::create_temp_child_context(Rc::clone(parent), obj.build())
     }
 
-    fn iterate_values(&self, values: Vec<Result<ValueEnum, RuntimeError>>, _list_type: ValueType, parent: Rc<RefCell<ExecutionContext>>) -> Result<ValueEnum, RuntimeError> {
+    fn iterate_values(
+        &self,
+        values: Vec<Result<ValueEnum, RuntimeError>>,
+        _list_type: ValueType,
+        parent: Rc<RefCell<ExecutionContext>>,
+    ) -> Result<ValueEnum, RuntimeError> {
         let mut result: Vec<Result<ValueEnum, RuntimeError>> = Vec::new();
 
         for value in values {
             let ctx = self.create_in_loop_context(&parent, Value(value?));
             //@Todo way too complex
-            let map_value = self.return_expression.borrow().expressions.get(RETURN_EXPRESSION).unwrap().borrow().expression.eval(ctx);
+            let map_value = self
+                .return_expression
+                .borrow()
+                .expressions
+                .get(RETURN_EXPRESSION)
+                .unwrap()
+                .borrow()
+                .expression
+                .eval(ctx);
             //@Todo return values only, not tokens
             result.push(map_value);
         }
 
         match self.return_type.clone()? {
-            ValueType::ListType(item_type) => {
-                Ok(Array(result, *item_type))
-            }
+            ValueType::ListType(item_type) => Ok(Array(result, *item_type)),
             err => {
-                RuntimeError::eval_error(format!("Cannot iterate through non list type `{}`", err)).into()
+                RuntimeError::eval_error(format!("Cannot iterate through non list type `{}`", err))
+                    .into()
             }
         }
     }
 
-    fn iterate_range(&self, values: Range<Integer>, parent: Rc<RefCell<ExecutionContext>>) -> Result<ValueEnum, RuntimeError> {
+    fn iterate_range(
+        &self,
+        values: Range<Integer>,
+        parent: Rc<RefCell<ExecutionContext>>,
+    ) -> Result<ValueEnum, RuntimeError> {
         let mut result: Vec<Result<ValueEnum, RuntimeError>> = Vec::new();
 
         for value in values {
             let ctx = self.create_in_loop_context(&parent, Value(ValueEnum::from(value)));
             //@Todo way too complex
-            let map_value = self.return_expression.borrow().expressions.get(RETURN_EXPRESSION).unwrap().borrow().expression.eval(ctx);
+            let map_value = self
+                .return_expression
+                .borrow()
+                .expressions
+                .get(RETURN_EXPRESSION)
+                .unwrap()
+                .borrow()
+                .expression
+                .eval(ctx);
             //@Todo return values only, not tokens
             result.push(map_value);
         }
@@ -110,7 +146,9 @@ impl EvaluatableExpression for ForFunction {
         match self.in_expression.eval(Rc::clone(&context))? {
             Array(values, list_type) => self.iterate_values(values, list_type, Rc::clone(&context)),
             RangeValue(range) => self.iterate_range(range, Rc::clone(&context)),
-            other => RuntimeError::eval_error(format!("Cannot iterate {}", other.get_type())).into(),
+            other => {
+                RuntimeError::eval_error(format!("Cannot iterate {}", other.get_type())).into()
+            }
         }
     }
 }
@@ -121,25 +159,37 @@ impl StaticLink for ForFunction {
             let list_type = self.in_expression.link(Rc::clone(&ctx))?;
 
             let item_type = match list_type {
-                ValueType::ListType(list_item_type) => {
-                    *list_item_type
-                }
-                ValueType::RangeType => {
-                    ValueType::NumberType
-                }
+                ValueType::ListType(list_item_type) => *list_item_type,
+                ValueType::RangeType => ValueType::NumberType,
                 _ => {
-                    return LinkingError::other_error(format!("Cannot iterate through non list type `{}`", list_type)).into();
+                    return LinkingError::other_error(format!(
+                        "Cannot iterate through non list type `{}`",
+                        list_type
+                    ))
+                    .into();
                 }
             };
 
             let for_parameter = FormalParameter::new(self.in_loop_variable.clone(), item_type);
 
-            self.return_expression.borrow_mut().parameters.push(for_parameter);
-            self.return_expression.borrow_mut().node = NodeData::new(NodeDataEnum::Internal(Rc::downgrade(&ctx)));
+            self.return_expression
+                .borrow_mut()
+                .parameters
+                .push(for_parameter);
+            self.return_expression.borrow_mut().node =
+                NodeData::new(NodeDataEnum::Internal(Rc::downgrade(&ctx)));
 
             link_parts(Rc::clone(&self.return_expression))?;
 
-            let field_type = self.return_expression.borrow().expressions.get(RETURN_EXPRESSION).unwrap().borrow().field_type.clone()?;
+            let field_type = self
+                .return_expression
+                .borrow()
+                .expressions
+                .get(RETURN_EXPRESSION)
+                .unwrap()
+                .borrow()
+                .field_type
+                .clone()?;
 
             self.return_type = Ok(ValueType::ListType(Box::new(field_type)));
         }

--- a/src/ast/functions/function_types.rs
+++ b/src/ast/functions/function_types.rs
@@ -1,18 +1,18 @@
+use crate::ast::context::context_object::ContextObject;
+use crate::ast::expression::{EvaluatableExpression, StaticLink};
+use crate::ast::functions::function_mix::*;
+use crate::ast::token::ExpressionEnum;
+use crate::ast::utils::array_to_code_sep;
+use crate::ast::{is_linked, Link};
+use crate::runtime::execution_context::*;
+use crate::typesystem::errors::{LinkingError, RuntimeError};
+use crate::typesystem::types::ValueType;
+use crate::typesystem::values::ValueEnum;
+use log::error;
 use std::cell::RefCell;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::rc::Rc;
-use crate::ast::expression::{EvaluatableExpression, StaticLink};
-use crate::ast::functions::function_mix::*;
-use crate::ast::token::{ExpressionEnum};
-use crate::runtime::execution_context::*;
-use crate::typesystem::errors::{LinkingError, RuntimeError};
-use crate::typesystem::types::{ValueType};
-use crate::typesystem::values::ValueEnum;
-use log::error;
-use crate::ast::context::context_object::ContextObject;
-use crate::ast::{is_linked, Link};
-use crate::ast::utils::array_to_code_sep;
 
 use phf::phf_map;
 
@@ -82,7 +82,11 @@ pub struct BinaryFunction {
 }
 
 impl BinaryFunction {
-    pub fn build(definition: BinaryFunctionDefinition, left: ExpressionEnum, right: ExpressionEnum) -> Self {
+    pub fn build(
+        definition: BinaryFunctionDefinition,
+        left: ExpressionEnum,
+        right: ExpressionEnum,
+    ) -> Self {
         BinaryFunction {
             left,
             right,
@@ -190,7 +194,12 @@ impl MultiFunction {
 
 impl Display for MultiFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({})", self.definition.name, array_to_code_sep(self.args.iter(), ", "))
+        write!(
+            f,
+            "{}({})",
+            self.definition.name,
+            array_to_code_sep(self.args.iter(), ", ")
+        )
     }
 }
 
@@ -221,5 +230,3 @@ impl EvaluatableExpression for MultiFunction {
         (self.definition.function)(values, self.return_type.clone()?)
     }
 }
-
-

--- a/src/ast/ifthenelse.rs
+++ b/src/ast/ifthenelse.rs
@@ -1,16 +1,16 @@
-use std::cell::RefCell;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-use std::rc::Rc;
+use crate::ast::context::context_object::ContextObject;
 use crate::ast::expression::{EvaluatableExpression, StaticLink};
-use crate::ast::token::{ExpressionEnum};
+use crate::ast::token::ExpressionEnum;
+use crate::ast::{is_linked, Link};
 use crate::runtime::execution_context::*;
 use crate::typesystem::errors::{LinkingError, ParseErrorEnum, RuntimeError};
 use crate::typesystem::types::{TypedValue, ValueType};
 use crate::typesystem::values::ValueEnum;
 use crate::utils::bracket_unwrap;
-use crate::ast::context::context_object::ContextObject;
-use crate::ast::{is_linked, Link};
+use std::cell::RefCell;
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct IfThenElseFunction {
@@ -22,16 +22,22 @@ pub struct IfThenElseFunction {
 
 impl Display for IfThenElseFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "if {} then {} else {}",
-               self.condition,
-               bracket_unwrap(format!("{}", self.then_expression)),
-               bracket_unwrap(format!("{}", self.else_expression))
+        write!(
+            f,
+            "if {} then {} else {}",
+            self.condition,
+            bracket_unwrap(format!("{}", self.then_expression)),
+            bracket_unwrap(format!("{}", self.else_expression))
         )
     }
 }
 
 impl IfThenElseFunction {
-    pub fn build(condition: ExpressionEnum, then_expression: ExpressionEnum, else_expression: ExpressionEnum) -> Result<Self, ParseErrorEnum> {
+    pub fn build(
+        condition: ExpressionEnum,
+        then_expression: ExpressionEnum,
+        else_expression: ExpressionEnum,
+    ) -> Result<Self, ParseErrorEnum> {
         Ok(IfThenElseFunction {
             condition,
             then_expression,
@@ -48,10 +54,18 @@ impl StaticLink for IfThenElseFunction {
             let then_expression = self.then_expression.link(Rc::clone(&ctx))?;
             self.result_type = self.else_expression.link(Rc::clone(&ctx));
 
-            LinkingError::expect_single_type("if condition", condition_type, &ValueType::BooleanType)?;
+            LinkingError::expect_single_type(
+                "if condition",
+                condition_type,
+                &ValueType::BooleanType,
+            )?;
 
             if let Ok(else_expression) = &self.result_type {
-                LinkingError::expect_same_types("`then` and `else` expressions", then_expression, else_expression.clone())?;
+                LinkingError::expect_same_types(
+                    "`then` and `else` expressions",
+                    then_expression,
+                    else_expression.clone(),
+                )?;
             }
         }
 

--- a/src/ast/metaphors/functions.rs
+++ b/src/ast/metaphors/functions.rs
@@ -1,16 +1,16 @@
 use std::cell::RefCell;
 
-use std::fmt::{Debug, Display, Formatter};
-use std::rc::Rc;
 use crate::ast::annotations::AnnotationEnum;
-use crate::ast::metaphors::metaphor::Metaphor;
-use crate::ast::utils::array_to_code_sep;
 use crate::ast::context::context_object::ContextObject;
 use crate::ast::context::context_object_type::FormalParameter;
-use crate::ast::context::function_context::{FunctionContext};
+use crate::ast::context::function_context::FunctionContext;
+use crate::ast::metaphors::metaphor::Metaphor;
+use crate::ast::utils::array_to_code_sep;
 use crate::ast::Link;
 use crate::link::linker;
 use crate::tokenizer::C_ASSIGN;
+use std::fmt::{Debug, Display, Formatter};
+use std::rc::Rc;
 
 use crate::typesystem::types::{TypedValue, ValueType};
 
@@ -22,39 +22,48 @@ pub struct FunctionDefinition {
     pub arguments: Vec<FormalParameter>,
     /// Function body later is used as a context object for execution context so it is Rc.
     /// RefCell is added only for linking purposes. Better to remove later.
-    pub body: Rc<RefCell<ContextObject>>
+    pub body: Rc<RefCell<ContextObject>>,
 }
 
 impl FunctionDefinition {
-    pub fn build(annotations: Vec<AnnotationEnum>, name: String, arguments: Vec<FormalParameter>, body: Rc<RefCell<ContextObject>>) -> Self {
+    pub fn build(
+        annotations: Vec<AnnotationEnum>,
+        name: String,
+        arguments: Vec<FormalParameter>,
+        body: Rc<RefCell<ContextObject>>,
+    ) -> Self {
         FunctionDefinition {
             annotations,
             name,
             arguments,
-            body
+            body,
         }
     }
 }
 
-impl Into<Rc<RefCell<dyn Metaphor + 'static>>> for FunctionDefinition {
-    fn into(self) -> Rc<RefCell<dyn Metaphor + 'static>> {
-        Rc::new(RefCell::new(self))
+impl From<FunctionDefinition> for Rc<RefCell<dyn Metaphor + 'static>> {
+    fn from(val: FunctionDefinition) -> Self {
+        Rc::new(RefCell::new(val))
     }
 }
 
-impl Into<Box<dyn Metaphor + 'static>> for FunctionDefinition {
-    fn into(self) -> Box<dyn Metaphor + 'static> {
-        Box::new(self)
+impl From<FunctionDefinition> for Box<dyn Metaphor + 'static> {
+    fn from(val: FunctionDefinition) -> Self {
+        Box::new(val)
     }
 }
 
 impl Display for FunctionDefinition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}({}) {} {}",
-               array_to_code_sep(self.annotations.iter(), "\n"),
-               self.name,
-               array_to_code_sep(self.arguments.iter(), ", "),
-               C_ASSIGN, self.body.borrow())
+        write!(
+            f,
+            "{}{}({}) {} {}",
+            array_to_code_sep(self.annotations.iter(), "\n"),
+            self.name,
+            array_to_code_sep(self.arguments.iter(), ", "),
+            C_ASSIGN,
+            self.body.borrow()
+        )
     }
 }
 
@@ -69,10 +78,11 @@ impl Metaphor for FunctionDefinition {
         self.name.clone()
     }
 
-    fn get_parameters(&self) -> &Vec<FormalParameter> { &self.arguments }
+    fn get_parameters(&self) -> &Vec<FormalParameter> {
+        &self.arguments
+    }
 
     fn create_context(&self, parameters: Vec<FormalParameter>) -> Link<FunctionContext> {
-
         parameters.iter().for_each(|arg| {
             self.body.borrow_mut().parameters.push(arg.clone());
         });

--- a/src/ast/metaphors/metaphor.rs
+++ b/src/ast/metaphors/metaphor.rs
@@ -1,12 +1,11 @@
 use std::fmt::{Debug, Display};
 
 use crate::ast::context::context_object_type::FormalParameter;
-use crate::ast::context::function_context::{FunctionContext};
+use crate::ast::context::function_context::FunctionContext;
 use crate::ast::Link;
 use crate::typesystem::types::TypedValue;
 
 pub trait Metaphor: Display + Debug + TypedValue {
-
     fn get_name(&self) -> String;
 
     /// metaphor interface

--- a/src/ast/metaphors/mod.rs
+++ b/src/ast/metaphors/mod.rs
@@ -1,3 +1,3 @@
 pub mod decision_tables;
-pub mod metaphor;
 pub mod functions;
+pub mod metaphor;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,19 +1,19 @@
 use crate::typesystem::errors::{ErrorStack, LinkingError, LinkingErrorEnum};
 
-pub mod token;
-pub mod selections;
-pub mod expression;
-pub mod utils;
-pub mod operators;
 pub mod annotations;
-pub mod metaphors;
-pub mod variable;
 pub mod context;
-pub mod sequence;
-pub mod ifthenelse;
+pub mod expression;
 pub mod foreach;
-pub mod user_function_call;
 pub mod functions;
+pub mod ifthenelse;
+pub mod metaphors;
+pub mod operators;
+pub mod selections;
+pub mod sequence;
+pub mod token;
+pub mod user_function_call;
+pub mod utils;
+pub mod variable;
 
 //----------------------------------------------------------------------------------------------
 

--- a/src/ast/operators/logical_operators.rs
+++ b/src/ast/operators/logical_operators.rs
@@ -1,20 +1,20 @@
+use crate::ast::context::context_object::ContextObject;
+use crate::ast::expression::{EvaluatableExpression, StaticLink};
+use crate::ast::operators::logical_operators::LogicalOperatorEnum::*;
+use crate::ast::operators::math_operators::{Operator, OperatorData};
+use crate::ast::token::{EPriorities, ExpressionEnum};
+use crate::ast::Link;
+use crate::runtime::execution_context::ExecutionContext;
+use crate::typesystem::errors::ParseErrorEnum::UnexpectedLiteral;
+use crate::typesystem::errors::{ParseErrorEnum, RuntimeError};
+use crate::typesystem::types::ValueType::BooleanType;
+use crate::typesystem::types::{TypedValue, ValueType};
+use crate::typesystem::values::ValueEnum;
+use crate::typesystem::values::ValueEnum::BooleanValue;
 use std::cell::RefCell;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::rc::Rc;
-use crate::ast::expression::{EvaluatableExpression, StaticLink};
-use crate::ast::operators::math_operators::{Operator, OperatorData};
-use crate::ast::token::{ExpressionEnum, EPriorities};
-use crate::ast::operators::logical_operators::LogicalOperatorEnum::*;
-use crate::ast::context::context_object::ContextObject;
-use crate::ast::Link;
-use crate::runtime::execution_context::ExecutionContext;
-use crate::typesystem::errors::{ParseErrorEnum, RuntimeError};
-use crate::typesystem::errors::ParseErrorEnum::{UnexpectedLiteral};
-use crate::typesystem::types::{TypedValue, ValueType};
-use crate::typesystem::types::ValueType::BooleanType;
-use crate::typesystem::values::ValueEnum;
-use crate::typesystem::values::ValueEnum::BooleanValue;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogicalOperatorEnum {
@@ -30,7 +30,7 @@ impl LogicalOperatorEnum {
             Not => "not",
             And => "and",
             Or => "or",
-            Xor => "xor"
+            Xor => "xor",
         }
     }
 }
@@ -44,7 +44,10 @@ impl TryFrom<&str> for LogicalOperatorEnum {
             "and" => Ok(And),
             "or" => Ok(Or),
             "xor" => Ok(Xor),
-            _ => Err(UnexpectedLiteral(value.to_string(), Some("not, and, or, xor".to_string())))
+            _ => Err(UnexpectedLiteral(
+                value.to_string(),
+                Some("not, and, or, xor".to_string()),
+            )),
         }
     }
 }
@@ -79,7 +82,11 @@ impl StaticLink for LogicalOperator {
 }
 
 impl LogicalOperator {
-    pub fn build(operator: LogicalOperatorEnum, left: ExpressionEnum, right: ExpressionEnum) -> Result<Self, ParseErrorEnum> {
+    pub fn build(
+        operator: LogicalOperatorEnum,
+        left: ExpressionEnum,
+        right: ExpressionEnum,
+    ) -> Result<Self, ParseErrorEnum> {
         let function = match operator {
             And => |left: &bool, right: &bool| *left && *right,
             Or => |left: &bool, right: &bool| *left || *right,
@@ -88,7 +95,11 @@ impl LogicalOperator {
         };
 
         Ok(LogicalOperator {
-            data: OperatorData { operator, left, right },
+            data: OperatorData {
+                operator,
+                left,
+                right,
+            },
             function,
         })
     }
@@ -100,8 +111,14 @@ impl EvaluatableExpression for LogicalOperator {
         let right_token = &self.data.right.eval(context)?;
 
         match (left_token, right_token) {
-            (BooleanValue(_left), BooleanValue(_right)) => Ok(BooleanValue((self.function)(_left, _right))),
-            _ => RuntimeError::eval_error(format!("Operator '{}' is not implemented for '{} {} {}'", self.data.operator, left_token, self.data.operator, right_token)).into(),
+            (BooleanValue(_left), BooleanValue(_right)) => {
+                Ok(BooleanValue((self.function)(_left, _right)))
+            }
+            _ => RuntimeError::eval_error(format!(
+                "Operator '{}' is not implemented for '{} {} {}'",
+                self.data.operator, left_token, self.data.operator, right_token
+            ))
+            .into(),
         }
     }
 }

--- a/src/ast/operators/mod.rs
+++ b/src/ast/operators/mod.rs
@@ -1,4 +1,3 @@
 pub mod comparators;
-pub mod math_operators;
 pub mod logical_operators;
-
+pub mod math_operators;

--- a/src/ast/sequence.rs
+++ b/src/ast/sequence.rs
@@ -1,16 +1,16 @@
-use std::cell::RefCell;
-use std::fmt::{Display, Formatter};
-use std::rc::Rc;
 use crate::ast::context::context_object::ContextObject;
-use crate::ast::expression::{StaticLink};
-use crate::ast::{is_linked, Link};
+use crate::ast::expression::StaticLink;
 use crate::ast::token::ExpressionEnum;
 use crate::ast::utils::array_to_code_sep;
+use crate::ast::{is_linked, Link};
 use crate::runtime::execution_context::ExecutionContext;
 use crate::typesystem::errors::{LinkingError, RuntimeError};
 use crate::typesystem::types::ValueType;
 use crate::typesystem::values::ValueEnum;
 use crate::typesystem::values::ValueEnum::Array;
+use std::cell::RefCell;
+use std::fmt::{Display, Formatter};
+use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct CollectionExpression {
@@ -44,7 +44,11 @@ impl CollectionExpression {
     }
 
     pub fn eval(&self, context: Rc<RefCell<ExecutionContext>>) -> Result<ValueEnum, RuntimeError> {
-        let results = self.elements.iter().map(|expr| expr.eval(Rc::clone(&context))).collect();
+        let results = self
+            .elements
+            .iter()
+            .map(|expr| expr.eval(Rc::clone(&context)))
+            .collect();
         Ok(Array(results, self.collection_item_type.clone()?))
     }
 }

--- a/src/ast/utils.rs
+++ b/src/ast/utils.rs
@@ -1,23 +1,22 @@
-use std::fmt::Display;
 use crate::typesystem::errors::RuntimeError;
+use std::fmt::Display;
 
 extern crate proc_macro;
 
-pub fn array_to_code_sep(parts: impl Iterator<Item=impl Display>, sep: &str) -> String {
-
-    parts.map(|s| format!("{}", s))
+pub fn array_to_code_sep(parts: impl Iterator<Item = impl Display>, sep: &str) -> String {
+    parts
+        .map(|s| format!("{}", s))
         .collect::<Vec<String>>()
         .join(sep)
 }
 
-pub fn results_to_code(parts: &Vec<Result<impl Display, RuntimeError>>) -> String {
+pub fn results_to_code(parts: &[Result<impl Display, RuntimeError>]) -> String {
     parts
         .iter()
-        .map(|s| {
-            match s {
-                Ok(p) => format!("{}", p),
-                Err(p) => format!("{}", p)
-            }
-        }).collect::<Vec<String>>()
+        .map(|s| match s {
+            Ok(p) => format!("{}", p),
+            Err(p) => format!("{}", p),
+        })
+        .collect::<Vec<String>>()
         .join(", ")
 }

--- a/src/bin/edgerules-wasi.rs
+++ b/src/bin/edgerules-wasi.rs
@@ -21,7 +21,9 @@ fn main() {
         }
     } else {
         let mut buf = String::new();
-        io::stdin().read_to_string(&mut buf).expect("Failed to read stdin");
+        io::stdin()
+            .read_to_string(&mut buf)
+            .expect("Failed to read stdin");
         buf
     };
 
@@ -47,4 +49,3 @@ fn eval_value(code: &str) -> Result<Option<String>, String> {
         Err(_) => Ok(None),
     }
 }
-

--- a/src/bin/generate-examples.rs
+++ b/src/bin/generate-examples.rs
@@ -24,9 +24,9 @@ fn main() -> std::io::Result<()> {
     // Helper to flush a completed code block to output, possibly replacing
     // placeholder blocks with evaluated output.
     let flush_block = |out: &mut fs::File,
-                           code_lang_is_edgerules: bool,
-                           block_lines: &mut Vec<String>,
-                           pending_eval_output: &mut Option<String>|
+                       code_lang_is_edgerules: bool,
+                       block_lines: &mut Vec<String>,
+                       pending_eval_output: &mut Option<String>|
      -> std::io::Result<()> {
         if code_lang_is_edgerules {
             // Determine if this is an output placeholder block (first non-empty trimmed line is `// output`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,47 +1,39 @@
-extern crate log;
 extern crate core;
+extern crate log;
 use crate::runtime::edge_rules::EdgeRules;
 use crate::utils::to_display;
-pub mod runtime;
-pub mod utils;
-mod tokenizer;
 mod ast;
-mod typesystem;
 mod link;
+pub mod runtime;
+mod tokenizer;
+mod typesystem;
+pub mod utils;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
 pub fn code_to_trace(code: &str) -> String {
     let mut engine = EdgeRules::new();
     match engine.load_source(code) {
-        Ok(_service) => {
-            match engine.to_runtime() {
-                Ok(runtime) => {
-                    match runtime.eval_all() {
-                        Ok(()) => runtime.context.borrow().to_code(),
-                        Err(error) => error.to_string()
-                    }
-                }
-                Err(error) => {
-                    error.to_string()
-                }
-            }
-        }
-        Err(error) => {
-            to_display(error.errors(), "\n")
-        }
+        Ok(_service) => match engine.to_runtime() {
+            Ok(runtime) => match runtime.eval_all() {
+                Ok(()) => runtime.context.borrow().to_code(),
+                Err(error) => error.to_string(),
+            },
+            Err(error) => error.to_string(),
+        },
+        Err(error) => to_display(error.errors(), "\n"),
     }
 }
 
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod test {
-    use std::fs;
-    use log::{trace};
+    use crate::code_to_trace;
     use crate::utils::test::{init_logger, init_test};
+    use log::trace;
+    use std::fs;
     use std::io::Write;
     use std::path::Path;
-    use crate::code_to_trace;
 
     fn process_file(input_file_name: &str) -> std::io::Result<()> {
         let output_file_name = format!("{}.out", input_file_name);
@@ -74,8 +66,6 @@ mod test {
 
     #[test]
     fn file_test() {
-
-
         // {
         //     let data = fs::read_to_string("tests/nested_1.txt").expect("Unable to read file");
         //     let trace = code_to_trace(data.as_str());
@@ -93,7 +83,6 @@ mod test {
             //debug!("{}", &trace);
             //assert_eq!(true, trace.contains("assignment side is not complete"))
         }
-
 
         {
             let _data = fs::read_to_string("tests/record_1.txt").expect("Unable to read file");

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -1,2 +1,2 @@
-pub mod node_data;
 pub mod linker;
+pub mod node_data;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,6 +1,6 @@
-pub mod utils;
-pub mod parser;
 mod builder;
+pub mod parser;
+pub mod utils;
 
 pub const C_ASSIGN: char = ':';
 
@@ -27,34 +27,82 @@ mod test {
         is_equals("value : 1 + -2", "value : 1 + -2");
         is_equals("value : -1 + 2", "value : -1 + 2");
         is_equals("value : - (-2*10)", "value:-(-(2*10))");
-        is_equals("value : (1 + 7 * (5 / 6 + (2-1))-1) - 8 / 3 * 10", "value:(1+(7*(5/6+(2-1))-1))-8/3*10");
-        is_equals("{ record : { age : 18; value : 1 + 2 }}", "{record:{age:18;value:1+2}}");
+        is_equals(
+            "value : (1 + 7 * (5 / 6 + (2-1))-1) - 8 / 3 * 10",
+            "value:(1+(7*(5/6+(2-1))-1))-8/3*10",
+        );
+        is_equals(
+            "{ record : { age : 18; value : 1 + 2 }}",
+            "{record:{age:18;value:1+2}}",
+        );
         is_equals("{ r : { a : 1 + 2} b : 3}", "{r:{a:1+2};b:3}");
         is_equals("{ r : { a : 1 + 2}; b : 3}", "{r:{a:1+2};b:3}"); // testing comma separator that should be OK
-        is_equals("{ record : { age1 : 11; variable : 100; variable : 200 }; record2 : { age2 : 22 }}", "{record:{age1:11;variable:200;variable:200};record2:{age2:22}}");
+        is_equals(
+            "{ record : { age1 : 11; variable : 100; variable : 200 }; record2 : { age2 : 22 }}",
+            "{record:{age1:11;variable:200;variable:200};record2:{age2:22}}",
+        );
         is_equals("value : [1,sum(9,8),3]", "value:[1,sum(9,8),3]");
-        is_equals("record(input) : { age : input.age } ", "record(input):{age:input.age}");
-        is_equals("{doublethis(input) : { out : input * input }; result : doublethis(2).out }", "{doublethis(input):{out:input*input};result:doublethis(2).out}");
-        is_equals("resultset : for x in [1,2,3] return x * 2", "resultset : for x in [1,2,3] return x * 2");
-        is_equals("applicants : [{age:23},{age:34}]", "applicants:[{age:23},{age:34}]");
+        is_equals(
+            "record(input) : { age : input.age } ",
+            "record(input):{age:input.age}",
+        );
+        is_equals(
+            "{doublethis(input) : { out : input * input }; result : doublethis(2).out }",
+            "{doublethis(input):{out:input*input};result:doublethis(2).out}",
+        );
+        is_equals(
+            "resultset : for x in [1,2,3] return x * 2",
+            "resultset : for x in [1,2,3] return x * 2",
+        );
+        is_equals(
+            "applicants : [{age:23},{age:34}]",
+            "applicants:[{age:23},{age:34}]",
+        );
         is_equals("p : [{a:1},5]", "p:[{a:1},5]");
         is_equals("myFunc(x,y,z) : {a : 1}", "myFunc(x,y,z):{a:1}");
-        is_equals("result : sales[month] + sales[month + 1] + sales[month + 2]", "result:(sales[month]+sales[(month+1)])+sales[(month+2)]");
+        is_equals(
+            "result : sales[month] + sales[month + 1] + sales[month + 2]",
+            "result:(sales[month]+sales[(month+1)])+sales[(month+2)]",
+        );
 
         // constraints
         is_equals("value : ...> 1 ", "value: ...> 1");
 
         // if, else
-        is_equals("value : if 1 > 2 then 1 else 2", "value : if 1 > 2 then 1 else 2");
-        is_equals("value : if (1 > 2) then 1 else 2", "value : if 1 > 2 then 1 else 2");
-        is_equals("value : if (1 > 2) then 1 else 2 * 5", "value: if 1 > 2 then 1 else 2 * 5");
-        is_equals("value : if (1 > 2 * 9) then 1 + 1 else 2 * 5", "value : if 1 > 2 * 9 then 1 + 1 else 2 * 5");
-        is_equals("value : if (1 > 2) then 1 else (if (2 > 3) then 2 else 3)", "value : if 1 > 2 then 1 else if 2 > 3 then 2 else 3");
+        is_equals(
+            "value : if 1 > 2 then 1 else 2",
+            "value : if 1 > 2 then 1 else 2",
+        );
+        is_equals(
+            "value : if (1 > 2) then 1 else 2",
+            "value : if 1 > 2 then 1 else 2",
+        );
+        is_equals(
+            "value : if (1 > 2) then 1 else 2 * 5",
+            "value: if 1 > 2 then 1 else 2 * 5",
+        );
+        is_equals(
+            "value : if (1 > 2 * 9) then 1 + 1 else 2 * 5",
+            "value : if 1 > 2 * 9 then 1 + 1 else 2 * 5",
+        );
+        is_equals(
+            "value : if (1 > 2) then 1 else (if (2 > 3) then 2 else 3)",
+            "value : if 1 > 2 then 1 else if 2 > 3 then 2 else 3",
+        );
 
         // @Todo: complete, 3 + 5 is a mistake
-        is_equals("value : (if (1 > 2) then 1 else (if (2 > 3) then 2 else 3)) + 5", "value : if 1 > 2 then 1 else if 2 > 3 then 2 else 3 + 5");
-        is_equals("value : if (1 > 2) then 1 else (if (2 > 3) then 2 else 3)", "value : if 1 > 2 then 1 else if 2 > 3 then 2 else 3");
-        is_equals("value : if (1 > 2) then (if (2 > 3) then 2 else 3) else (if (2 > 3) then 2 else 3)", "value : if 1 > 2 then if 2 > 3 then 2 else 3 else if 2 > 3 then 2 else 3");
+        is_equals(
+            "value : (if (1 > 2) then 1 else (if (2 > 3) then 2 else 3)) + 5",
+            "value : if 1 > 2 then 1 else if 2 > 3 then 2 else 3 + 5",
+        );
+        is_equals(
+            "value : if (1 > 2) then 1 else (if (2 > 3) then 2 else 3)",
+            "value : if 1 > 2 then 1 else if 2 > 3 then 2 else 3",
+        );
+        is_equals(
+            "value : if (1 > 2) then (if (2 > 3) then 2 else 3) else (if (2 > 3) then 2 else 3)",
+            "value : if 1 > 2 then if 2 > 3 then 2 else 3 else if 2 > 3 then 2 else 3",
+        );
 
         // string type
         is_equals("value : 'hello'", "value:'hello'");
@@ -66,23 +114,50 @@ mod test {
         is_equals("value : [1,2,3][0]", "value:[1,2,3][0]");
         is_equals("value : [1,2,3][>1]", "value:[1,2,3][...>1]");
         is_equals("value : [1,2,3][...>1]", "value:[1,2,3][...>1]");
-        is_equals("value : [1,2,3][...>=2 and ...<=3]", "value:[1,2,3][...>=2 and ...<=3]");
+        is_equals(
+            "value : [1,2,3][...>=2 and ...<=3]",
+            "value:[1,2,3][...>=2 and ...<=3]",
+        );
         is_equals("value : [1,2,3][position-1]", "value:[1,2,3][(position-1)]");
-        is_equals("value : application.applicant[0]", "value:application.applicant[0]");
-        is_equals("value : application.applicant[0].age", "value:application.applicant[0].age");
-        is_equals("value : application.applicant[<=1].age", "value:application.applicant[...<=1].age");
-        is_equals("value : application.applicant[sum(1,2)].age", "value:application.applicant[sum(1,2)].age");
+        is_equals(
+            "value : application.applicant[0]",
+            "value:application.applicant[0]",
+        );
+        is_equals(
+            "value : application.applicant[0].age",
+            "value:application.applicant[0].age",
+        );
+        is_equals(
+            "value : application.applicant[<=1].age",
+            "value:application.applicant[...<=1].age",
+        );
+        is_equals(
+            "value : application.applicant[sum(1,2)].age",
+            "value:application.applicant[sum(1,2)].age",
+        );
 
         // Variable and variable path:
         is_equals("value : subContext", "value : subContext");
         is_equals("value : subContext*1", "value : subContext*1");
-        is_equals("value : subContext.subResult", "value : subContext.subResult");
-        is_equals("value : subContext.subResult+1", "value : subContext.subResult+1");
+        is_equals(
+            "value : subContext.subResult",
+            "value : subContext.subResult",
+        );
+        is_equals(
+            "value : subContext.subResult+1",
+            "value : subContext.subResult+1",
+        );
 
         // Nested arrays
         is_equals("value : [1,2,3]", "value:[1,2,3]");
-        is_equals("value : [[key,value],[1,2],[3,4]]", "value : [[key,value],[1,2],[3,4]]");
-        is_equals("value : [[key,value],[,2],[3,4]]", "Veryfirstsequenceelementismissing→'value'assignmentsideisnotcomplete");
+        is_equals(
+            "value : [[key,value],[1,2],[3,4]]",
+            "value : [[key,value],[1,2],[3,4]]",
+        );
+        is_equals(
+            "value : [[key,value],[,2],[3,4]]",
+            "Veryfirstsequenceelementismissing→'value'assignmentsideisnotcomplete",
+        );
 
         // Various functions
         is_equals("value : max(1) + 1", "value : max(1) + 1");
@@ -91,10 +166,13 @@ mod test {
         is_equals("value : count([1,2,3]) + 1", "value : count([1,2,3]) + 1");
 
         // Complex structures
-        is_equals("{ p : [{a:1},5] }","{ p : [{a:1},5] }");
+        is_equals("{ p : [{a:1},5] }", "{ p : [{a:1},5] }");
 
         // Testing annotations:
-        is_equals("@Service myFunc(x,y,z) : {a : 1}", "@Service myFunc(x,y,z) : {a : 1}");
+        is_equals(
+            "@Service myFunc(x,y,z) : {a : 1}",
+            "@Service myFunc(x,y,z) : {a : 1}",
+        );
         //is_equals("@DecisionTable myFunc(x,y) : [[x,y,z],[1,2,3]]", "@DecisionTable(\"\"first-hit\"\") myFunc(x:any,y:any) : [[x,y,z],[x=1,y=2,3]]");
     }
 
@@ -102,7 +180,10 @@ mod test {
     fn test_errors() {
         init_logger();
 
-        is_equals("p : [{a:},5]", "'a'assignmentsideisnotcomplete→'p'assignmentsideisnotcomplete");
+        is_equals(
+            "p : [{a:},5]",
+            "'a'assignmentsideisnotcomplete→'p'assignmentsideisnotcomplete",
+        );
     }
 
     #[test]
@@ -110,9 +191,18 @@ mod test {
         init_logger();
 
         is_equals("p : 1..5", "p : 1..5");
-        is_equals("p : for number in 1..5 return number * 2", "p : for number in 1..5 return number * 2");
-        is_equals("p : for number in 1..(5+inc) return number * 3", "p : for number in 1..(5+inc) return number * 3");
-        is_equals("p : for number in 1 * 0 .. 5+inc return number * 3", "p : for number in 1*0..(5+inc) return number * 3");
+        is_equals(
+            "p : for number in 1..5 return number * 2",
+            "p : for number in 1..5 return number * 2",
+        );
+        is_equals(
+            "p : for number in 1..(5+inc) return number * 3",
+            "p : for number in 1..(5+inc) return number * 3",
+        );
+        is_equals(
+            "p : for number in 1 * 0 .. 5+inc return number * 3",
+            "p : for number in 1*0..(5+inc) return number * 3",
+        );
     }
 
     #[test]
@@ -120,8 +210,14 @@ mod test {
         init_logger();
 
         is_equals("p : sum(2,2 * sum(1,1))", "p : sum(2,2 * sum(1,1))");
-        is_equals("p : sum(2 * sum(3,3),2 * sum(1,1))", "p : sum(2 * sum(3,3),2 * sum(1,1))");
-        is_equals("value : sum(1,2,3 + sum(2,2 * sum(0,0,0,0))) + (2 * 2)", "value:sum(1,2,(3+sum(2,2*sum(0,0,0,0))))+2*2");
+        is_equals(
+            "p : sum(2 * sum(3,3),2 * sum(1,1))",
+            "p : sum(2 * sum(3,3),2 * sum(1,1))",
+        );
+        is_equals(
+            "value : sum(1,2,3 + sum(2,2 * sum(0,0,0,0))) + (2 * 2)",
+            "value:sum(1,2,(3+sum(2,2*sum(0,0,0,0))))+2*2",
+        );
         is_equals("value : [1,1*sum(9,8^3)^2,3]", "value:[1,1*sum(9,8^3)^2,3]");
     }
 

--- a/src/tokenizer/builder.rs
+++ b/src/tokenizer/builder.rs
@@ -1,15 +1,19 @@
-use std::fmt;
-use std::collections::vec_deque::VecDeque;
-use log::{error, trace};
 use crate::ast::token::EToken;
 use crate::ast::token::EToken::Expression;
 use crate::ast::token::ExpressionEnum::{Value, Variable};
 use crate::tokenizer::utils::TokenChain;
-use crate::utils::to_string;
 use crate::typesystem::errors::ParseErrorEnum;
 use crate::typesystem::values::ValueEnum;
+use crate::utils::to_string;
+use log::{error, trace};
+use std::collections::vec_deque::VecDeque;
+use std::fmt;
 
-type FactoryFunction = fn(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum>;
+type FactoryFunction = fn(
+    left: &mut TokenChain,
+    token: EToken,
+    right: &mut TokenChain,
+) -> Result<EToken, ParseErrorEnum>;
 
 //----------------------------------------------------------------------------------------------
 
@@ -53,16 +57,27 @@ impl ASTBuilder {
     }
 
     pub fn merge_level(&mut self, current_level: u32) {
-        trace!("merge_left_if_can. lastPriorityList={}",to_string(&mut self.last_priority_list.clone()));
+        trace!(
+            "merge_left_if_can. lastPriorityList={}",
+            to_string(&mut self.last_priority_list.clone())
+        );
 
         while let Some(check_build_task) = self.last_priority_list.back() {
-
             // eliminate bigger priority items from the left side
             if check_build_task.priority >= current_level {
-                trace!("merge this: '{:?}' at '{:?}' lvl={}", self.result[check_build_task.position],check_build_task.position,current_level);
+                trace!(
+                    "merge this: '{:?}' at '{:?}' lvl={}",
+                    self.result[check_build_task.position],
+                    check_build_task.position,
+                    current_level
+                );
 
                 if let Some(build_task) = self.last_priority_list.pop_back() {
-                    trace!("full = {:?} --- split at {}", self.result, build_task.position);
+                    trace!(
+                        "full = {:?} --- split at {}",
+                        self.result,
+                        build_task.position
+                    );
 
                     let mut right = TokenChain(self.result.split_off(build_task.position));
 
@@ -72,7 +87,8 @@ impl ASTBuilder {
                         trace!("mid = {:?}", token);
                         trace!("right = {:?}", right);
 
-                        let build_result = (build_task.factory)(&mut self.result, token, &mut right);
+                        let build_result =
+                            (build_task.factory)(&mut self.result, token, &mut right);
 
                         match build_result {
                             Ok(token) => self.result.push_back(token),
@@ -89,9 +105,19 @@ impl ASTBuilder {
                 }
             } else {
                 if let Some(token) = self.result.get(check_build_task.position) {
-                    trace!("no merge: position={} item={} lvl={} lastPriorityList={}",check_build_task.position, token,current_level,to_string(&mut self.last_priority_list.clone()));
+                    trace!(
+                        "no merge: position={} item={} lvl={} lastPriorityList={}",
+                        check_build_task.position,
+                        token,
+                        current_level,
+                        to_string(&mut self.last_priority_list.clone())
+                    );
                 } else {
-                    trace!("no merge: position={} left={:?}",check_build_task.position, self.result);
+                    trace!(
+                        "no merge: position={} left={:?}",
+                        check_build_task.position,
+                        self.result
+                    );
                 }
 
                 break;
@@ -128,7 +154,10 @@ impl ASTBuilder {
     }
 
     pub fn finalize(mut self) -> TokenChain {
-        trace!("Finalizing. lastPriorityList={}",to_string(&mut self.last_priority_list.clone()));
+        trace!(
+            "Finalizing. lastPriorityList={}",
+            to_string(&mut self.last_priority_list.clone())
+        );
 
         // @TODO need to make sure that infinity loop will not occur
         while self.last_priority_list.back().is_some() {
@@ -166,32 +195,37 @@ impl ASTBuilder {
 //--------------------------------------------------------------------------------------------------
 
 pub mod factory {
-    use std::collections::vec_deque::VecDeque;
-    use log::trace;
     use crate::ast::annotations::AnnotationEnum;
     use crate::ast::context::context_object_builder::ContextObjectBuilder;
     use crate::ast::context::context_object_type::FormalParameter;
     use crate::ast::foreach::ForFunction;
-    use crate::ast::operators::comparators::{ComparatorEnum, ComparatorOperator};
-    use crate::ast::token::*;
-    use crate::ast::token::EToken::*;
-    use crate::ast::operators::logical_operators::{LogicalOperator, LogicalOperatorEnum};
-    use crate::ast::operators::math_operators::{MathOperator, MathOperatorEnum, NegationOperator};
-    use crate::ast::selections::{ExpressionFilter, FieldSelection};
-    use crate::ast::token::ExpressionEnum::*;
-    use crate::ast::token::EUnparsedToken::*;
-    use crate::tokenizer::utils::*;
-    use crate::ast::token::{EToken};
-    use crate::ast::functions::function_types::{BINARY_BUILT_IN_FUNCTIONS, BinaryFunction, BUILT_IN_ALL_FUNCTIONS, MULTI_BUILT_IN_FUNCTIONS, MultiFunction, UNARY_BUILT_IN_FUNCTIONS, UnaryFunction};
+    use crate::ast::functions::function_types::{
+        BinaryFunction, MultiFunction, UnaryFunction, BINARY_BUILT_IN_FUNCTIONS,
+        BUILT_IN_ALL_FUNCTIONS, MULTI_BUILT_IN_FUNCTIONS, UNARY_BUILT_IN_FUNCTIONS,
+    };
     use crate::ast::ifthenelse::IfThenElseFunction;
     use crate::ast::metaphors::decision_tables::DecisionTable;
     use crate::ast::metaphors::functions::FunctionDefinition;
+    use crate::ast::operators::comparators::{ComparatorEnum, ComparatorOperator};
+    use crate::ast::operators::logical_operators::{LogicalOperator, LogicalOperatorEnum};
+    use crate::ast::operators::math_operators::{MathOperator, MathOperatorEnum, NegationOperator};
+    use crate::ast::selections::{ExpressionFilter, FieldSelection};
     use crate::ast::sequence::CollectionExpression;
     use crate::ast::token::DefinitionEnum::MetaphorDefinition;
+    use crate::ast::token::EToken;
+    use crate::ast::token::EToken::*;
+    use crate::ast::token::EUnparsedToken::*;
+    use crate::ast::token::ExpressionEnum::*;
+    use crate::ast::token::*;
     use crate::ast::user_function_call::UserFunctionCall;
+    use crate::tokenizer::utils::*;
     use crate::typesystem::errors::ParseErrorEnum;
-    use crate::typesystem::errors::ParseErrorEnum::{FunctionWrongNumberOfArguments, UnknownError, UnknownParseError};
-    use crate::typesystem::types::{ValueType};
+    use crate::typesystem::errors::ParseErrorEnum::{
+        FunctionWrongNumberOfArguments, UnknownError, UnknownParseError,
+    };
+    use crate::typesystem::types::ValueType;
+    use log::trace;
+    use std::collections::vec_deque::VecDeque;
 
     fn pop_back_as_expected(deque: &mut VecDeque<EToken>, expected: &str) -> bool {
         if let Some(Unparsed(Literal(maybe))) = deque.pop_back() {
@@ -203,46 +237,68 @@ pub mod factory {
         false
     }
 
-    pub fn build_assignment(left: &mut TokenChain, _token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
-        let left_token = left.pop_left()
-            .map_err(|err| UnknownError("Left assignment side is not complete".to_string()).before(err))?;
+    pub fn build_assignment(
+        left: &mut TokenChain,
+        _token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
+        let left_token = left.pop_left().map_err(|err| {
+            UnknownError("Left assignment side is not complete".to_string()).before(err)
+        })?;
 
-        let right_token = right.pop_right()
-            .map_err(|err| UnknownError(format!("'{}' assignment side is not complete", left_token)).before(err))?;
+        let right_token = right.pop_right().map_err(|err| {
+            UnknownError(format!("'{}' assignment side is not complete", left_token)).before(err)
+        })?;
 
         match (left_token, right_token) {
             (Expression(Variable(link)), Expression(right)) => {
                 Ok(Expression(ObjectField(link.get_name(), Box::new(right))))
             }
-            (Unparsed(FunctionDefinitionLiteral(annotations, function_name, arguments)), Expression(StaticObject(object))) => {
-
+            (
+                Unparsed(FunctionDefinitionLiteral(annotations, function_name, arguments)),
+                Expression(StaticObject(object)),
+            ) => {
                 // let plain = SimpleObject::try_unwrap(object)
                 //     .map_err(|_err| UnknownError(format!("'{}' failed to construct", function_name)))?;
 
-                Ok(Definition(MetaphorDefinition(FunctionDefinition::build(annotations, function_name, arguments, object).into())))
+                Ok(Definition(MetaphorDefinition(
+                    FunctionDefinition::build(annotations, function_name, arguments, object).into(),
+                )))
             }
-            (Unparsed(FunctionDefinitionLiteral(annotations, function_name, _arguments)), Expression(Collection(_rows))) => {
+            (
+                Unparsed(FunctionDefinitionLiteral(annotations, function_name, _arguments)),
+                Expression(Collection(_rows)),
+            ) => {
                 if AnnotationEnum::get_decision_table(&annotations).is_some() {
-                    let decision_table = DecisionTable::build(annotations, function_name, _arguments, _rows)?;
+                    let decision_table =
+                        DecisionTable::build(annotations, function_name, _arguments, _rows)?;
                     Ok(Definition(MetaphorDefinition(Box::new(decision_table))))
                 } else {
-                    Err(UnknownError(format!("function '{}' body is a collection. Must be a structure", function_name)))
+                    Err(UnknownError(format!(
+                        "function '{}' body is a collection. Must be a structure",
+                        function_name
+                    )))
                 }
             }
-            (Unparsed(FunctionDefinitionLiteral(_annotations, name, _)), _) => {
-                Err(UnknownError(format!("function '{}' body is not defined", name)))
-            }
-            (unexpected, Expression(_right)) => {
-                Err(UnknownError(format!("'{}' cannot be a variable name", unexpected)))
-            }
-            (a, b) => {
-                Err(UnknownError(format!("'{}' is not proper variable name to assign '{}'", a, b)))
-            }
+            (Unparsed(FunctionDefinitionLiteral(_annotations, name, _)), _) => Err(UnknownError(
+                format!("function '{}' body is not defined", name),
+            )),
+            (unexpected, Expression(_right)) => Err(UnknownError(format!(
+                "'{}' cannot be a variable name",
+                unexpected
+            ))),
+            (a, b) => Err(UnknownError(format!(
+                "'{}' is not proper variable name to assign '{}'",
+                a, b
+            ))),
         }
     }
 
-    pub fn build_context(_left: &mut TokenChain, _token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
-
+    pub fn build_context(
+        _left: &mut TokenChain,
+        _token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         // @Todo: need to check level before adding and stop adding if smaller
         let mut obj = ContextObjectBuilder::new();
 
@@ -263,13 +319,19 @@ pub mod factory {
 
                 // @Todo: need to accumulate errors instead of just returning - same applies for an array
                 Unparsed(unparsed) => {
-                    return Err(UnknownError(format!("'{}' is not a proper context element", unparsed)));
+                    return Err(UnknownError(format!(
+                        "'{}' is not a proper context element",
+                        unparsed
+                    )));
                 }
                 ParseError(error) => {
                     return Err(error);
                 }
                 _ => {
-                    return Err(UnknownError(format!("'{}' is not a proper object field", right_token)));
+                    return Err(UnknownError(format!(
+                        "'{}' is not a proper object field",
+                        right_token
+                    )));
                 }
             }
         }
@@ -277,46 +339,69 @@ pub mod factory {
         Ok(Expression(StaticObject(obj.build())))
     }
 
-    pub fn build_function_call(_left: &mut TokenChain, function_name: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
+    pub fn build_function_call(
+        _left: &mut TokenChain,
+        function_name: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         let name_result = function_name.into_string_or_literal()?;
         let name = name_result.as_str();
-        let mut expressions = right.into_expressions()?;
+        let mut expressions = right.drain_expressions()?;
 
         if expressions.len() == 1 {
             if let Some(function) = UNARY_BUILT_IN_FUNCTIONS.get(name) {
                 let expression = expressions.pop().unwrap();
-                return Ok(Expression(UnaryFunction::build(function.clone(), expression).into()));
+                return Ok(Expression(
+                    UnaryFunction::build(function.clone(), expression).into(),
+                ));
             }
         } else if expressions.len() == 2 {
             if let Some(function) = BINARY_BUILT_IN_FUNCTIONS.get(name) {
                 let right_expression = expressions.pop().unwrap();
                 let left_expression = expressions.pop().unwrap();
-                return Ok(Expression(BinaryFunction::build(function.clone(), left_expression, right_expression).into()));
+                return Ok(Expression(
+                    BinaryFunction::build(function.clone(), left_expression, right_expression)
+                        .into(),
+                ));
             }
         }
 
         if !expressions.is_empty() {
             if let Some(function) = MULTI_BUILT_IN_FUNCTIONS.get(name) {
-                return Ok(Expression(MultiFunction::build(function.clone(), expressions).into()));
+                return Ok(Expression(
+                    MultiFunction::build(function.clone(), expressions).into(),
+                ));
             }
         }
 
-        return match BUILT_IN_ALL_FUNCTIONS.get(name) {
+        match BUILT_IN_ALL_FUNCTIONS.get(name) {
             None => {
                 if !expressions.is_empty() {
-                    Ok(Expression(FunctionCall(Box::new(UserFunctionCall::new(name.to_string(), expressions)))))
+                    Ok(Expression(FunctionCall(Box::new(UserFunctionCall::new(
+                        name.to_string(),
+                        expressions,
+                    )))))
                 } else {
-                    Err(UnknownError(format!("{} function does not have any arguments", name)))
+                    Err(UnknownError(format!(
+                        "{} function does not have any arguments",
+                        name
+                    )))
                 }
             }
-            Some(finding) => {
-                Err(FunctionWrongNumberOfArguments(name.to_string(), finding.clone(), expressions.len()))
-            }
-        };
+            Some(finding) => Err(FunctionWrongNumberOfArguments(
+                name.to_string(),
+                finding.clone(),
+                expressions.len(),
+            )),
+        }
     }
 
     // create tokens chain
-    pub fn build_function_definition(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
+    pub fn build_function_definition(
+        left: &mut TokenChain,
+        token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         let mut arguments = Vec::new();
         let mut annotations = Vec::new();
 
@@ -336,20 +421,33 @@ pub mod factory {
             match right_token {
                 Unparsed(Comma) => {
                     if arguments.is_empty() {
-                        return Err(UnknownError(format!("Very first function argument is missing")));
+                        return Err(UnknownError(
+                            "Very first function argument is missing".to_string(),
+                        ));
                     }
                 }
                 _ => {
                     // @Todo: implement type parsing
-                    arguments.push(FormalParameter::new(format!("{}", right_token), ValueType::UndefinedType));
+                    arguments.push(FormalParameter::new(
+                        format!("{}", right_token),
+                        ValueType::UndefinedType,
+                    ));
                 }
             }
         }
 
-        Ok(Unparsed(FunctionDefinitionLiteral(annotations, token.into_string_or_literal()?, arguments)))
+        Ok(Unparsed(FunctionDefinitionLiteral(
+            annotations,
+            token.into_string_or_literal()?,
+            arguments,
+        )))
     }
 
-    pub fn build_sequence(_left: &mut TokenChain, _token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
+    pub fn build_sequence(
+        _left: &mut TokenChain,
+        _token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         let mut args: Vec<ExpressionEnum> = Vec::new();
 
         // Todo: need to check level before adding and stop adding if smaller, but for some reasons no errors can be reproduced.
@@ -359,7 +457,9 @@ pub mod factory {
                 Unparsed(Comma) => {
                     if args.is_empty() {
                         right.clear(); // forgets all possible other errors
-                        return Err(UnknownError(format!("Very first sequence element is missing")));
+                        return Err(UnknownError(
+                            "Very first sequence element is missing".to_string(),
+                        ));
                     }
                 }
                 ParseError(error) => {
@@ -368,38 +468,50 @@ pub mod factory {
                 }
                 Unparsed(_) => {
                     right.clear(); // forgets all possible other errors
-                    return Err(UnknownError(format!("'{}' is not a proper sequence element", right_token)));
+                    return Err(UnknownError(format!(
+                        "'{}' is not a proper sequence element",
+                        right_token
+                    )));
                 }
                 Definition(_) => {
                     right.clear(); // forgets all possible other errors
-                    return Err(UnknownError(format!("Function definition is not allowed in sequence")));
+                    return Err(UnknownError(
+                        "Function definition is not allowed in sequence".to_string(),
+                    ));
                 }
             }
         }
 
         if args.is_empty() {
-            return Err(UnknownError(format!("Function definition is not allowed in sequence")));
+            return Err(UnknownError(
+                "Function definition is not allowed in sequence".to_string(),
+            ));
         }
 
         Ok(Expression(Collection(CollectionExpression::build(args))))
     }
 
-    pub fn build_filter(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
-
+    pub fn build_filter(
+        left: &mut TokenChain,
+        token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         // application.applicants[0].age
         // left-----------------^   ^------right
 
-        let left_token = left.pop_left()
-            .map_err(|err| UnknownError(format!("Filter not applicable")).before(err))?;
+        let left_token = left
+            .pop_left()
+            .map_err(|err| UnknownError("Filter not applicable".to_string()).before(err))?;
 
-        let right_token = right.pop_right()
-            .map_err(|err| UnknownError(format!("Filter '{}' not applicable", left_token)).before(err))?;
+        let right_token = right.pop_right().map_err(|err| {
+            UnknownError(format!("Filter '{}' not applicable", left_token)).before(err)
+        })?;
 
         match (left_token, right_token) {
             (Expression(left_expression), Expression(right_expression)) => {
                 match ExpressionFilter::build(left_expression, right_expression) {
                     Ok(selection) => Ok(Expression(Filter(Box::new(selection)))),
-                    Err(error) => Err(error)
+                    Err(error) => Err(error),
                 }
             }
             (_left_unknown, _right_unknown) => {
@@ -408,64 +520,84 @@ pub mod factory {
         }
     }
 
-    pub fn build_range(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
-
+    pub fn build_range(
+        left: &mut TokenChain,
+        token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         // number in 1..5
         // left------^  ^------right
 
-        let left_token = left.pop_left()
-            .map_err(|err| UnknownError(format!("Range not applicable")).before(err))?;
+        let left_token = left
+            .pop_left()
+            .map_err(|err| UnknownError("Range not applicable".to_string()).before(err))?;
 
-        let right_token = right.pop_right()
-            .map_err(|err| UnknownError(format!("Range '{}' not applicable", left_token)).before(err))?;
+        let right_token = right.pop_right().map_err(|err| {
+            UnknownError(format!("Range '{}' not applicable", left_token)).before(err)
+        })?;
 
         match (left_token, right_token) {
-            (Expression(left_expression), Expression(right_expression)) => {
-                Ok(Expression(RangeExpression(Box::new(left_expression), Box::new(right_expression))))
-            }
-            (_left_unknown, _right_unknown) => {
-                Err(ParseErrorEnum::UnknownParseError(format!("Range not completed '{}'", token)))
-            }
+            (Expression(left_expression), Expression(right_expression)) => Ok(Expression(
+                RangeExpression(Box::new(left_expression), Box::new(right_expression)),
+            )),
+            (_left_unknown, _right_unknown) => Err(ParseErrorEnum::UnknownParseError(format!(
+                "Range not completed '{}'",
+                token
+            ))),
         }
     }
 
-    pub fn build_field_selection(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
-
+    pub fn build_field_selection(
+        left: &mut TokenChain,
+        token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         // application.applicants[0].age
         // left-----------------^   ^------right
 
-        let left_token = left.pop_left().map_err(|_| UnknownError(format!("Field not applicable")))?;
-        let right_token = right.pop_right().map_err(|_| UnknownError(format!("Field '{}' not applicable", left_token)))?;
+        let left_token = left
+            .pop_left()
+            .map_err(|_| UnknownError("Field not applicable".to_string()))?;
+        let right_token = right
+            .pop_right()
+            .map_err(|_| UnknownError(format!("Field '{}' not applicable", left_token)))?;
 
         match (left_token, right_token) {
             (Expression(left_expression), Expression(right_expression)) => {
                 match FieldSelection::build(left_expression, right_expression) {
                     Ok(selection) => Ok(Expression(Selection(Box::new(selection)))),
-                    Err(error) => Err(error)
+                    Err(error) => Err(error),
                 }
             }
-            (_left_unknown, _right_unknown) => {
-                Err(UnknownParseError(format!("Selection not completed '{}'", token)))
-            }
+            (_left_unknown, _right_unknown) => Err(UnknownParseError(format!(
+                "Selection not completed '{}'",
+                token
+            ))),
         }
     }
 
-    pub fn build_if_then_else(left: &mut TokenChain, _token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
-
+    pub fn build_if_then_else(
+        left: &mut TokenChain,
+        _token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         // ... if ... then ... else ...
         // left---------------^    ^-----------------right
 
-        let then_content = left.pop_left_expression()
+        let then_content = left
+            .pop_left_expression()
             .map_err(|err| UnknownError("Error in then... part".to_string()).before(err))?;
 
         let _then = left.pop_left_as_expected("then")?;
 
-        let if_condition = left.pop_left_expression()
+        let if_condition = left
+            .pop_left_expression()
             .map_err(|err| UnknownError("Error in if... part".to_string()).before(err))?;
 
         let _if_part = left.pop_left_as_expected("if")?;
 
-        let else_content = right.pop_right_expression()
+        let else_content = right
+            .pop_right_expression()
             .map_err(|err| UnknownError("Error in else... part".to_string()).before(err))?;
 
         let func = IfThenElseFunction::build(if_condition, then_content, else_content)?;
@@ -473,8 +605,11 @@ pub mod factory {
         Ok(Expression(FunctionCall(Box::new(func))))
     }
 
-    pub fn build_for_each_return(left: &mut TokenChain, _token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
-
+    pub fn build_for_each_return(
+        left: &mut TokenChain,
+        _token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         // ... for in_loop_variable in in_expression return return_expression
         // left-------------------------------------^       ^-----------------right
 
@@ -483,42 +618,56 @@ pub mod factory {
                 if pop_back_as_expected(left, "in") {
                     if let Some(Expression(in_loop_variable)) = left.pop_back() {
                         if pop_back_as_expected(left, "for") {
-                            Expression(FunctionCall(Box::new(
-                                ForFunction::new(format!("{}", in_loop_variable), in_expression, return_expression)
-                            )))
+                            Expression(FunctionCall(Box::new(ForFunction::new(
+                                format!("{}", in_loop_variable),
+                                in_expression,
+                                return_expression,
+                            ))))
                         } else {
-                            return Err(UnknownParseError(format!("??? ... in ... return ...")));
+                            return Err(UnknownParseError("??? ... in ... return ...".to_string()));
                         }
                     } else {
-                        return Err(UnknownParseError(format!("for [???] in ... return ...")));
+                        return Err(UnknownParseError("for [???] in ... return ...".to_string()));
                     }
                 } else {
-                    return Err(UnknownParseError(format!("for ... [in?] ... return ...")));
+                    return Err(UnknownParseError(
+                        "for ... [in?] ... return ...".to_string(),
+                    ));
                 }
             } else {
-                return Err(UnknownParseError(format!("for ... in [???] return ...")));
+                return Err(UnknownParseError("for ... in [???] return ...".to_string()));
             }
         } else {
-            return Err(UnknownParseError(format!("for ... in ... return [???]")));
+            return Err(UnknownParseError("for ... in ... return [???]".to_string()));
         };
 
         Ok(new_token)
     }
 
-    pub fn build_any_operator(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
+    pub fn build_any_operator(
+        left: &mut TokenChain,
+        token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         let op = MathOperatorEnum::try_from(token)?;
-        let left_token = left.pop_left().map_err(|err| UnknownError(format!("Left '{}' operator side is not complete", op)).before(err))?;
-        let right_token = right.pop_right().map_err(|err| UnknownError(format!("{} {} - not completed", left_token, op)).before(err))?;
+        let left_token = left.pop_left().map_err(|err| {
+            UnknownError(format!("Left '{}' operator side is not complete", op)).before(err)
+        })?;
+        let right_token = right.pop_right().map_err(|err| {
+            UnknownError(format!("{} {} - not completed", left_token, op)).before(err)
+        })?;
 
         match (left_token, right_token) {
-            (Expression(_left), Expression(_right)) => {
-                Ok(Expression(Operator(Box::new(MathOperator::build(op, _left, _right)?))))
-            }
+            (Expression(_left), Expression(_right)) => Ok(Expression(Operator(Box::new(
+                MathOperator::build(op, _left, _right)?,
+            )))),
             (Unparsed(_left), Expression(_right)) => {
                 // @Todo: that's absolutely not clear
                 left.push_back(Unparsed(_left));
                 if op == MathOperatorEnum::Subtraction {
-                    Ok(Expression(FunctionCall(Box::new(NegationOperator::new(_right)))))
+                    Ok(Expression(FunctionCall(Box::new(NegationOperator::new(
+                        _right,
+                    )))))
                 } else {
                     Err(UnknownError(format!("Not completed '{}'", op)))
                 }
@@ -530,49 +679,62 @@ pub mod factory {
         }
     }
 
-    pub fn build_comparator(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
+    pub fn build_comparator(
+        left: &mut TokenChain,
+        token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         let comparator = ComparatorEnum::try_from(token.into_string_or_literal()?.as_str())?;
 
-        let left_token = left.pop_left()
-            .map_err(|err| UnknownError(format!("Left '{}' comparator side is not complete", comparator)).before(err))?;
+        let left_token = left.pop_left().map_err(|err| {
+            UnknownError(format!(
+                "Left '{}' comparator side is not complete",
+                comparator
+            ))
+            .before(err)
+        })?;
 
-        let right_token = right.pop_right()
-            .map_err(|err| UnknownError(format!("{} {} - not completed", left_token, comparator)).before(err))?;
+        let right_token = right.pop_right().map_err(|err| {
+            UnknownError(format!("{} {} - not completed", left_token, comparator)).before(err)
+        })?;
 
         match (left_token, right_token) {
             (Expression(left_token), Expression(right_token)) => {
-                let comparator_operator = ComparatorOperator::build(comparator, left_token, right_token)?;
+                let comparator_operator =
+                    ComparatorOperator::build(comparator, left_token, right_token)?;
                 Ok(Expression(Operator(Box::new(comparator_operator))))
             }
             (Unparsed(BracketOpen), Expression(right_token)) => {
                 left.push_back(Unparsed(BracketOpen));
-                let comparator_operator = ComparatorOperator::build(comparator, ContextVariable, right_token)?;
+                let comparator_operator =
+                    ComparatorOperator::build(comparator, ContextVariable, right_token)?;
                 Ok(Expression(Operator(Box::new(comparator_operator))))
             }
-            (_left, _right) => {
-                Err(UnknownError(format!("Not completed '{}'", comparator)))
-            }
+            (_left, _right) => Err(UnknownError(format!("Not completed '{}'", comparator))),
         }
     }
 
-    pub fn build_logical_operator(left: &mut TokenChain, token: EToken, right: &mut TokenChain) -> Result<EToken, ParseErrorEnum> {
+    pub fn build_logical_operator(
+        left: &mut TokenChain,
+        token: EToken,
+        right: &mut TokenChain,
+    ) -> Result<EToken, ParseErrorEnum> {
         let operator = LogicalOperatorEnum::try_from(token.into_string_or_literal()?.as_str())?;
 
-        let left_token = left.pop_left()
-            .map_err(|err| UnknownError(format!("Left '{}' operator side is not complete", operator)).before(err))?;
+        let left_token = left.pop_left().map_err(|err| {
+            UnknownError(format!("Left '{}' operator side is not complete", operator)).before(err)
+        })?;
 
-        let right_token = right.pop_right()
-            .map_err(|err| UnknownError(format!("{} {} - not completed", left_token, operator)).before(err))?;
+        let right_token = right.pop_right().map_err(|err| {
+            UnknownError(format!("{} {} - not completed", left_token, operator)).before(err)
+        })?;
 
         match (left_token, right_token) {
             (Expression(left_token), Expression(right_token)) => {
                 let function = LogicalOperator::build(operator, left_token, right_token)?;
                 Ok(Expression(Operator(Box::new(function))))
             }
-            (_left, _right) => {
-                Err(UnknownError(format!("Not completed '{}'", operator)))
-            }
+            (_left, _right) => Err(UnknownError(format!("Not completed '{}'", operator))),
         }
     }
 }
-

--- a/src/typesystem/mod.rs
+++ b/src/typesystem/mod.rs
@@ -1,3 +1,3 @@
-pub mod types;
 pub mod errors;
+pub mod types;
 pub mod values;

--- a/src/typesystem/types.rs
+++ b/src/typesystem/types.rs
@@ -1,14 +1,9 @@
+use crate::ast::context::context_object::ContextObject;
+use crate::typesystem::errors::ParseErrorEnum;
 use std::cell::RefCell;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::rc::Rc;
-use crate::ast::context::context_object::ContextObject;
-use crate::typesystem::errors::ParseErrorEnum;
-
-
-
-
-
 
 pub trait TypedValue {
     fn get_type(&self) -> ValueType;
@@ -25,6 +20,7 @@ pub trait TypedValue {
 /// FEEL related documentation:
 /// https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-data-types/
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum ValueType {
     NumberType,
     StringType,
@@ -51,7 +47,6 @@ pub enum ValueType {
     ObjectType(Rc<RefCell<ContextObject>>),
 
     UndefinedType,
-
     // Todo: remove it and update
     //AnyType,
 }
@@ -60,7 +55,7 @@ impl ValueType {
     pub fn get_list_type(&self) -> Option<ValueType> {
         match self {
             ValueType::ListType(list_type) => Some(*list_type.clone()),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -83,7 +78,7 @@ impl Display for ValueType {
 
             // Todo: remove it
             //ValueType::AnyType => f.write_str("any"),
-            ValueType::UndefinedType => f.write_str("undefined")
+            ValueType::UndefinedType => f.write_str("undefined"),
         }
     }
 }
@@ -95,7 +90,9 @@ impl TryFrom<&str> for ValueType {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         if value.starts_with("list of ") {
             let value = value.replace("list of ", "");
-            return Ok(ValueType::ListType(Box::new(ValueType::try_from(value.as_str())?)));
+            return Ok(ValueType::ListType(Box::new(ValueType::try_from(
+                value.as_str(),
+            )?)));
         }
 
         match value {
@@ -163,13 +160,13 @@ pub type Integer = i64;
 //--------------------------------------------------------------------------------------------------
 
 pub mod number {
+    use crate::typesystem::types::number::NumberEnum::{Fraction, Int, Real, SV};
+    use crate::typesystem::types::ValueType::NumberType;
+    use crate::typesystem::types::{Float, Integer, SpecialValueEnum, TypedValue, ValueType};
     use std::cmp::Ordering;
     use std::fmt;
     use std::fmt::{Debug, Display, Formatter};
     use std::ops::{Add, Div, Mul, Rem, Sub};
-    use crate::typesystem::types::{ValueType, Float, Integer, SpecialValueEnum, TypedValue};
-    use crate::typesystem::types::number::NumberEnum::{Fraction, Int, Real, SV};
-    use crate::typesystem::types::ValueType::NumberType;
 
     #[allow(non_snake_case)]
     #[derive(Debug, PartialEq, Clone)]
@@ -181,7 +178,6 @@ pub mod number {
     }
 
     impl NumberEnum {
-
         pub const ZERO: i64 = 0;
 
         pub fn negate(&self) -> NumberEnum {
@@ -203,7 +199,9 @@ pub mod number {
     }
 
     impl TypedValue for NumberEnum {
-        fn get_type(&self) -> ValueType { NumberType }
+        fn get_type(&self) -> ValueType {
+            NumberType
+        }
     }
 
     impl Display for NumberEnum {
@@ -343,10 +341,10 @@ pub mod number {
 //--------------------------------------------------------------------------------------------------
 
 pub mod string {
-    use std::cmp::Ordering;
-    use std::fmt::{Display};
-    use crate::typesystem::types::{SpecialValueEnum, TypedValue, ValueType};
     use crate::typesystem::types::ValueType::StringType;
+    use crate::typesystem::types::{SpecialValueEnum, TypedValue, ValueType};
+    use std::cmp::Ordering;
+    use std::fmt::Display;
 
     #[allow(non_snake_case)]
     #[derive(Debug, PartialEq, Clone)]
@@ -402,7 +400,6 @@ pub mod string {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use crate::typesystem::types::number::NumberEnum;
@@ -411,18 +408,41 @@ mod test {
 
     #[test]
     fn test_numbers() {
-
         // Add
-        assert_eq!(NumberEnum::from(10) + NumberEnum::SV(Missing), NumberEnum::from(10));
-        assert_eq!(NumberEnum::SV(Missing) + NumberEnum::from(10), NumberEnum::from(10));
-        assert_eq!(NumberEnum::from(10) + NumberEnum::from(10), NumberEnum::from(20));
-        assert_eq!(NumberEnum::SV(NotFound) + NumberEnum::from(10), NumberEnum::SV(NotFound));
+        assert_eq!(
+            NumberEnum::from(10) + NumberEnum::SV(Missing),
+            NumberEnum::from(10)
+        );
+        assert_eq!(
+            NumberEnum::SV(Missing) + NumberEnum::from(10),
+            NumberEnum::from(10)
+        );
+        assert_eq!(
+            NumberEnum::from(10) + NumberEnum::from(10),
+            NumberEnum::from(20)
+        );
+        assert_eq!(
+            NumberEnum::SV(NotFound) + NumberEnum::from(10),
+            NumberEnum::SV(NotFound)
+        );
 
         // Rem
-        assert_eq!(NumberEnum::from(10) % NumberEnum::SV(Missing), NumberEnum::from(10));
-        assert_eq!(NumberEnum::SV(Missing) % NumberEnum::from(10), NumberEnum::SV(Missing));
-        assert_eq!(NumberEnum::from(10) % NumberEnum::from(10), NumberEnum::from(0));
-        assert_eq!(NumberEnum::SV(NotFound) % NumberEnum::from(10), NumberEnum::SV(NotFound));
+        assert_eq!(
+            NumberEnum::from(10) % NumberEnum::SV(Missing),
+            NumberEnum::from(10)
+        );
+        assert_eq!(
+            NumberEnum::SV(Missing) % NumberEnum::from(10),
+            NumberEnum::SV(Missing)
+        );
+        assert_eq!(
+            NumberEnum::from(10) % NumberEnum::from(10),
+            NumberEnum::from(0)
+        );
+        assert_eq!(
+            NumberEnum::SV(NotFound) % NumberEnum::from(10),
+            NumberEnum::SV(NotFound)
+        );
 
         assert_eq!(NumberEnum::from(10) > NumberEnum::from(10), false);
 
@@ -443,11 +463,17 @@ mod test {
         assert_eq!(NumberEnum::SV(NotFound) == NumberEnum::from(10), false);
 
         assert_eq!(NumberEnum::SV(Missing) == NumberEnum::SV(NotFound), false);
-        assert_eq!(NumberEnum::SV(Missing) == NumberEnum::SV(NotApplicable), false);
+        assert_eq!(
+            NumberEnum::SV(Missing) == NumberEnum::SV(NotApplicable),
+            false
+        );
 
         assert_eq!(NumberEnum::SV(Missing) == NumberEnum::SV(Missing), true);
         assert_eq!(NumberEnum::SV(NotFound) == NumberEnum::SV(NotFound), true);
-        assert_eq!(NumberEnum::SV(NotApplicable) == NumberEnum::SV(NotApplicable), true);
+        assert_eq!(
+            NumberEnum::SV(NotApplicable) == NumberEnum::SV(NotApplicable),
+            true
+        );
     }
 
     #[test]

--- a/src/typesystem/values.rs
+++ b/src/typesystem/values.rs
@@ -1,22 +1,23 @@
+use crate::ast::context::context_object::ContextObject;
+use crate::ast::context::context_object_type::EObjectContent;
+use crate::typesystem::errors::RuntimeError;
+use crate::typesystem::types::number::NumberEnum;
+use crate::typesystem::types::string::StringEnum;
+use crate::typesystem::types::{Float, Integer, SpecialValueEnum, TypedValue, ValueType};
 use std::cell::RefCell;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use crate::typesystem::errors::RuntimeError;
-use crate::typesystem::types::number::NumberEnum;
 use std::ops::Range;
 use std::rc::Rc;
-use crate::typesystem::types::{Integer, ValueType, TypedValue, SpecialValueEnum, Float};
-use crate::typesystem::types::string::StringEnum;
 use time::{Date, PrimitiveDateTime, Time};
-use crate::ast::context::context_object::ContextObject;
-use crate::ast::context::context_object_type::EObjectContent;
 
 use crate::ast::utils::results_to_code;
 
 use crate::runtime::execution_context::ExecutionContext;
 use crate::typesystem::types::string::StringEnum::String;
-use crate::typesystem::values::ValueEnum::{Array, BooleanValue, NumberValue, RangeValue, Reference, StringValue};
-
+use crate::typesystem::values::ValueEnum::{
+    Array, BooleanValue, NumberValue, RangeValue, Reference, StringValue,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ValueOrSv<OkValue, SpecialValue> {
@@ -46,17 +47,15 @@ pub enum ValueEnum {
 impl From<ValueEnum> for EObjectContent<ExecutionContext> {
     fn from(value: ValueEnum) -> Self {
         match value {
-            Reference(reference) => {
-                EObjectContent::ObjectRef(reference)
-            }
-            other => EObjectContent::ConstantValue(other)
+            Reference(reference) => EObjectContent::ObjectRef(reference),
+            other => EObjectContent::ConstantValue(other),
         }
     }
 }
 
 impl From<ValueType> for EObjectContent<ContextObject> {
     fn from(value: ValueType) -> Self {
-        return EObjectContent::Definition(value)
+        EObjectContent::Definition(value)
     }
 }
 
@@ -106,19 +105,25 @@ impl Display for ValueEnum {
             NumberValue(number) => write!(f, "{}", number),
             StringValue(str) => write!(f, "{}", str),
             Reference(reference) => write!(f, "{}", reference.borrow()),
-            BooleanValue(value) => if *value { f.write_str("true") } else { f.write_str("false") },
+            BooleanValue(value) => {
+                if *value {
+                    f.write_str("true")
+                } else {
+                    f.write_str("false")
+                }
+            }
             RangeValue(range) => write!(f, "{}..{}", range.start, range.end - 1),
             ValueEnum::DateValue(date) => match date {
-                ValueOrSv::Value(date) => write!(f, "{}", date.to_string()),
-                ValueOrSv::Sv(sv) => write!(f, "{}", sv)
+                ValueOrSv::Value(date) => write!(f, "{}", date),
+                ValueOrSv::Sv(sv) => write!(f, "{}", sv),
             },
             ValueEnum::TimeValue(time) => match time {
-                ValueOrSv::Value(time) => write!(f, "{}", time.to_string()),
-                ValueOrSv::Sv(sv) => write!(f, "{}", sv)
+                ValueOrSv::Value(time) => write!(f, "{}", time),
+                ValueOrSv::Sv(sv) => write!(f, "{}", sv),
             },
             ValueEnum::DateTimeValue(date_time) => match date_time {
-                ValueOrSv::Value(date_time) => write!(f, "{}", date_time.to_string()),
-                ValueOrSv::Sv(sv) => write!(f, "{}", sv)
+                ValueOrSv::Value(date_time) => write!(f, "{}", date_time),
+                ValueOrSv::Sv(sv) => write!(f, "{}", sv),
             },
             ValueEnum::TypeValue(type_value) => {
                 write!(f, "{}", type_value)
@@ -158,12 +163,16 @@ impl From<&str> for ValueEnum {
     }
 }
 
-impl<T> From<Vec<T>> for ValueEnum where T: Into<ValueEnum> {
+impl<T> From<Vec<T>> for ValueEnum
+where
+    T: Into<ValueEnum>,
+{
     fn from(values: Vec<T>) -> Self {
         if values.is_empty() {
             Array(Vec::new(), ValueType::UndefinedType)
         } else {
-            let values_enum = values.into_iter()
+            let values_enum = values
+                .into_iter()
                 .map(|value| Ok(value.into()))
                 .collect::<Vec<Result<ValueEnum, RuntimeError>>>();
 
@@ -189,4 +198,3 @@ impl<T> From<Vec<T>> for ValueEnum where T: Into<ValueEnum> {
 //         }
 //     }
 // }
-

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,4 @@
-#![cfg(target_arch = "wasm32")]
+#![cfg(all(target_arch = "wasm32", feature = "wasm"))]
 
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
## Summary
- compile wasm bindings only when the `wasm` feature is enabled so WASI builds don't require `wasm-bindgen`
- resolve extensive Clippy warnings across annotations, runtime, and utilities

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `npm run build:wasm:node` *(fails: wasm-pack installation lengthy, build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a0ea933c832d9fc79821c7355b84