### PR TITLE
Gate WASM panic hook behind feature flag

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,9 +5,9 @@ use wasm_bindgen::prelude::*;
 use crate::code_to_trace;
 use crate::runtime::edge_rules::EdgeRules;
 
+#[cfg(feature = "console_error_panic_hook")]
 #[wasm_bindgen]
 pub fn init_panic_hook() {
-    #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 }
 


### PR DESCRIPTION
## Summary
- Export `init_panic_hook` only when `console_error_panic_hook` feature is enabled

## Testing
- `cargo fmt -- src/wasm.rs`
- `cargo test`
- `cargo clippy -- -D warnings` *(fails: unused import, variable mutability, needless return, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9875845e4832d8d568c55c844ea7d